### PR TITLE
Context return value mechanism

### DIFF
--- a/src/Support/Context.cpp
+++ b/src/Support/Context.cpp
@@ -34,7 +34,17 @@ void Context::pop(){
 	parent = nullptr;
 }
 
+void Context::pop(void* data){
+	parent->returned(data);
+	new ContextTransition(*screen.getDisplay(), this, parent, true);
+	parent = nullptr;
+}
+
 void Context::push(Context* parent){
 	this->parent = parent;
 	new ContextTransition(*screen.getDisplay(), parent, this);
+}
+
+void Context::returned(void* data){
+
 }

--- a/src/Support/Context.h
+++ b/src/Support/Context.h
@@ -21,7 +21,9 @@ public:
 	virtual void unpack();
 
 	void pop();
+	void pop(void* data);
 	void push(Context* parent);
+	virtual void returned(void* data);
 
 	Screen& getScreen();
 


### PR DESCRIPTION
Adds a mechanism for a Context to return a value to it's parent Context. This can be useful, for example, if you have a text input Context that can be called throughout your application and returns the user-inputted text.

## Additions to Context class
* ```void pop(void *)``` - can be called when exiting from a Context, and accepts a pointer to the data that should be returned to the parent Context
* ```void returned(void *)``` - called in the parent Context when the child has exited with data. Called before ```unpack()```

## Usage
In the child Context (TextInputContext in this example)
```c++
void inputConfirmed(char* text){
  pop(text);
}
```

In the parent Context
```c++
void returned(void* data){
  char* text = static_cast<char*>(data):
  Serial.println("TextInput Context returned with %s\n", text);
  delete data;
}
```

**Make sure to free the returned data after using it, as it will stay in the memory and will cause memory leakage otherwise.**