### PR TITLE
Added optional u8g2 font support

### DIFF
--- a/Setup.hpp
+++ b/Setup.hpp
@@ -28,3 +28,7 @@
 // #define CIRCUITOS_MPU6050
 // #define CIRCUITOS_LEDMATRIX
 // #define CIRCUITOS_SERIALFLASH
+
+/** Using u8g2 fonts uses up some RAM and PROGMEM for every font used.
+ * The U8g2_for_TFT_eSPI library is used. (https://github.com/Bodmer/U8g2_for_TFT_eSPI)*/
+// #define CIRCUITOS_U8G2FONTS

--- a/src/Display/Sprite.cpp
+++ b/src/Display/Sprite.cpp
@@ -4,7 +4,7 @@
 #include <pgmspace.h>
 
 #ifdef CIRCUITOS_U8G2FONTS
-U8g2_for_TFT_eSPI u8f;
+FontWriter u8f;
 #endif
 
 Sprite::Sprite(TFT_eSPI* spi, uint16_t width, uint16_t height) : TFT_eSprite(spi){
@@ -291,11 +291,8 @@ Sprite::~Sprite(){
 }
 
 #ifdef CIRCUITOS_U8G2FONTS
-void Sprite::startU8g2Fonts(){
+FontWriter& Sprite::startU8g2Fonts(){
 	u8f.begin(*this);
+	return u8f;
 }
-U8g2_for_TFT_eSPI* Sprite::getU8f(){
-	return &u8f;
-}
-
 #endif

--- a/src/Display/Sprite.cpp
+++ b/src/Display/Sprite.cpp
@@ -3,6 +3,9 @@
 #include "../Util/Debug.h"
 #include <pgmspace.h>
 
+#ifdef CIRCUITOS_U8G2FONTS
+U8g2_for_TFT_eSPI u8f;
+#endif
 
 Sprite::Sprite(TFT_eSPI* spi, uint16_t width, uint16_t height) : TFT_eSprite(spi){
 	parent = nullptr;
@@ -286,3 +289,13 @@ Sprite* Sprite::getParent() const{
 Sprite::~Sprite(){
 	deleteSprite();
 }
+
+#ifdef CIRCUITOS_U8G2FONTS
+void Sprite::startU8g2Fonts(){
+	u8f.begin(*this);
+}
+U8g2_for_TFT_eSPI* Sprite::getU8f(){
+	return &u8f;
+}
+
+#endif

--- a/src/Display/Sprite.h
+++ b/src/Display/Sprite.h
@@ -9,6 +9,7 @@
 
 #ifdef CIRCUITOS_U8G2FONTS
 #include <U8g2_for_TFT_eSPI.h>
+typedef U8g2_for_TFT_eSPI FontWriter;
 #endif
 
 class Display;
@@ -53,8 +54,7 @@ public:
 
 	Sprite* getParent() const;
 #ifdef CIRCUITOS_U8G2FONTS
-	void startU8g2Fonts();
-	U8g2_for_TFT_eSPI* getU8f();
+	FontWriter& startU8g2Fonts();
 #endif
 
 private:

--- a/src/Display/Sprite.h
+++ b/src/Display/Sprite.h
@@ -5,6 +5,11 @@
 #include <TFT_eSPI.h>
 #include "Display.h"
 #include "Color.h"
+#include "../../Setup.hpp"
+
+#ifdef CIRCUITOS_U8G2FONTS
+#include <U8g2_for_TFT_eSPI.h>
+#endif
 
 class Display;
 
@@ -47,6 +52,10 @@ public:
 	void setParent(Sprite* parent);
 
 	Sprite* getParent() const;
+#ifdef CIRCUITOS_U8G2FONTS
+	void startU8g2Fonts();
+	U8g2_for_TFT_eSPI* getU8f();
+#endif
 
 private:
 	Sprite* parent;


### PR DESCRIPTION
Sample usage:

```display.getBaseSprite()->startU8g2Fonts();
display.getBaseSprite()->startU8g2Fonts();
auto u8f = display.getBaseSprite()->getU8f();
u8f->setFont(u8g2_font_HelvetiPixel_tr);
u8f->setFontMode(1);                 // use u8g2 transparent mode (this is default)
u8f->setFontDirection(0);            // left to right (this is default)
u8f->setForegroundColor(TFT_WHITE);  // apply color
u8f->setCursor(5, 15);                // start writing at this position
u8f->print("Testerino");