### PR TITLE
Update Sprite.cpp

### DIFF
--- a/src/Display/Sprite.cpp
+++ b/src/Display/Sprite.cpp
@@ -240,6 +240,14 @@ Sprite& Sprite::setPos(int32_t x, int32_t y){
 	return *this;
 }
 
+/* TODO:
+ * when compiled without 'build_flags = -w' option the following error is issued:
+ *
+ * lib\CircuitOS\src\Display\Sprite.cpp: In member function 'Sprite& Sprite::resize(uint, uint)':
+ * lib\CircuitOS\src\Display\Sprite.cpp:214:5: error: control reaches end of non-void function [-Werror=return-type]
+ * 214 |  if(_created == false){
+ *     |     ^~~~~~~~
+*/
 Sprite& Sprite::resize(uint width, uint height){
 	if(!_created){
 		createSprite(width, height);
@@ -257,10 +265,25 @@ Sprite& Sprite::resize(uint width, uint height){
 	}
 }
 
+/* TODO:
+ * when compiled without 'build_flags = -w' option the following error is issued:
+ * lib\CircuitOS\src\Display\Sprite.cpp: In member function 'Sprite& Sprite::setTransparent(bool)':
+ * lib\CircuitOS\src\Display\Sprite.cpp:221:1: error: no return statement in function returning non-void [-Werror=return-type]
+ * 221 | }
+ *     | ^
+*/
 Sprite& Sprite::setTransparent(bool transparent){
 	chroma = transparent;
 }
 
+/* TODO:
+ * when compiled without 'build_flags = -w' option the following error is issued:
+ *
+ * lib\CircuitOS\src\Display\Sprite.cpp: In member function 'Sprite& Sprite::setChroma(Color)':
+ * lib\CircuitOS\src\Display\Sprite.cpp:226:1: error: no return statement in function returning non-void [-Werror=return-type]
+ * 226 | }
+ *     | ^
+*/
 Sprite& Sprite::setChroma(Color color){
 	chromaKey = color;
 	chroma = true;


### PR DESCRIPTION
TODO's added regarding errors when compiling without 'build_flags = -w' option