### PR TITLE
Fixed crash during LoopListeners find() when listeners are empty

### DIFF
--- a/src/Loop/LoopManager.cpp
+++ b/src/Loop/LoopManager.cpp
@@ -77,7 +77,7 @@ void LoopManager::loop(){
 	LoopManager::deferred.clear();
 
 	for(auto listener : listeners){
-		if(removedListeners.find(listener) != removedListeners.end()){
+		if(removedListeners.empty() || removedListeners.find(listener) != removedListeners.end()){
 			continue;
 		}
 		listener->loop(delta);
@@ -86,7 +86,7 @@ void LoopManager::loop(){
 	clearListeners();
 	insertListeners();
 
-	for(auto def : deferred){
+	for(const auto& def : deferred){
 		def(delta);
 	}
 	deferred.clear();


### PR DESCRIPTION
Occured on ESP8266, probably due to old faulty implementations in the old arduino-esp core